### PR TITLE
change path of cookie-DB for edge and chrome

### DIFF
--- a/src/ApertaCookie/Private/Get-OSCookieInfo.ps1
+++ b/src/ApertaCookie/Private/Get-OSCookieInfo.ps1
@@ -32,11 +32,11 @@ function Get-OSCookieInfo {
         Write-Verbose -Message 'Windows Detected'
         switch ($Browser) {
             Edge {
-                $sqlPath = "$env:LOCALAPPDATA\Microsoft\Edge\User Data\Default\Cookies"
+                $sqlPath = "$env:LOCALAPPDATA\Microsoft\Edge\User Data\Default\Network\Cookies"
                 $tableName = 'cookies'
             }
             Chrome {
-                $sqlPath = "$env:LOCALAPPDATA\Google\Chrome\User Data\Default\Cookies"
+                $sqlPath = "$env:LOCALAPPDATA\Google\Chrome\User Data\Default\Network\Cookies"
                 $tableName = 'cookies'
             }
             FireFox {


### PR DESCRIPTION
in essence, chromium changed the location of the cookies-database since chromium v96:
https://bugs.chromium.org/p/chromium/issues/detail?id=1173622
https://twitter.com/parityzero/status/1449033853457207302

# Pull Request

## Issue

Issue #4 , if available:

## Description

Description of changes:

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
